### PR TITLE
Docker-based test script for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: required
+
+language: bash
+
+services:
+  - docker
+
+script:
+  - scripts/ci.sh

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,16 @@
+FROM buildpack-deps:stretch
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends qemu grub-pc-bin xorriso \
+    && mkdir /chaos
+
+WORKDIR /chaos
+COPY dev /chaos/dev
+COPY drivers /chaos/drivers
+COPY include /chaos/include
+COPY kernel /chaos/kernel
+COPY lib /chaos/lib
+COPY scripts /chaos/scripts
+COPY Makefile /chaos/Makefile
+
+RUN make iso

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,26 @@
+#!/bin/sh -e
+
+cd "$(dirname "$0")"
+cd ..
+
+docker build -t chaos -f scripts/Dockerfile .
+
+docker run --rm --name chaos -d chaos \
+	qemu-system-i386 \
+		-nographic \
+		-serial stdio \
+		-monitor none \
+		-boot d \
+		-cdrom chaos.iso
+
+sleep 2
+
+logs=$(docker logs chaos)
+docker stop chaos
+
+echo $logs
+
+case "$logs" in
+	*"Init finished"*) exit;;
+	*) exit 1;;
+esac


### PR DESCRIPTION
Builds the image, runs qemu and asserts it outputs "Init finished". It works with the serial driver you just added.

The kernel could probably be built without Docker with `language: c` in `travis-ci.yml`. However, running `qemu` on Travis without Docker is really painful.

(It’s a bit quick and dirty, this script is quite slow since the Dockerfile installs `qemu grub-pc-bin xorriso` on each build. It would be faster to pull a qemu-enabled image from the Docker Hub, sharing the sources with a volume or building `chaos.bin` on the host.)

Of course, you have to enable Travis on https://travis-ci.org/.