### PR TITLE
Run the tests when the multiboot command-line contains "test"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,11 @@ LD		?= ld
 LDFLAGS		+= -n --gc-sections -m elf_i386 -T arch/$(ARCH)/kernel.ld
 
 
-all:		$(KERNEL) $(ISO)
+all:		$(ISO)
 
 iso:		$(ISO)
+
+test:		test_iso monitor
 
 kernel:		$(KERNEL)
 
@@ -63,6 +65,10 @@ $(KERNEL):	$(OBJS)
 
 $(ISO):		$(KERNEL)
 		echo -e "  SHELL\t chaos-iso.sh"
+		./scripts/chaos-iso.sh
+
+test_iso:	export CHAOS_BOOT_ARGS=test
+test_iso:	$(KERNEL)
 		./scripts/chaos-iso.sh
 
 clean:

--- a/include/kernel/options.h
+++ b/include/kernel/options.h
@@ -1,0 +1,22 @@
+/* ------------------------------------------------------------------------ *\
+**
+**  This file is part of the Chaos Kernel, and is made available under
+**  the terms of the GNU General Public License version 2.
+**
+**  Copyright (C) 2017 - Benjamin Grange <benjamin.grange@epitech.eu>
+**
+\* ------------------------------------------------------------------------ */
+
+#ifndef _KERNEL_OPTIONS_H_
+# define _KERNEL_OPTIONS_H_
+
+#include <stdbool.h>
+
+struct options {
+	bool test;
+};
+
+void		options_parse_command_line(char const *string);
+struct options	get_options(void);
+
+#endif /* !_KERNEL_OPTIONS_H_ */

--- a/include/kernel/pmm.h
+++ b/include/kernel/pmm.h
@@ -36,7 +36,7 @@ void				free_frame(phys_addr_t);
 
 /* Physical Memory Manager init */
 void				pmm_init(void);
-void				pmm_unit_tests(void);
+void				pmm_test(void);
 
 
 #endif /* !_KERNEL_PMM_H_ */

--- a/include/lib/libc/string.h
+++ b/include/lib/libc/string.h
@@ -25,4 +25,6 @@ int		memcmp(void const *s1, void const *s2, size_t n) __pure;
 void		*memchr(void const *src, int c, size_t n) __pure;
 void 		*memmove(void *dest, void const *src, size_t n);
 
+void		string_test(void);
+
 #endif /* !_LIBC_STRING_H_ */

--- a/include/lib/libc/string.h
+++ b/include/lib/libc/string.h
@@ -17,6 +17,7 @@
 */
 
 size_t		strlen(char const *) __pure;
+char		*strstr(char const *haystack, char const *needle) __pure;
 
 void		*memset(void *src, int c, size_t n);
 void		*memcpy(void *dest, void const *src, size_t n);

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -10,24 +10,10 @@
 #include <kernel/init.h>
 #include <kernel/pmm.h>
 #include <kernel/vmm.h>
+#include <kernel/options.h>
 #include <multiboot2.h>
 #include <stdio.h>
 #include <string.h>
-
-struct options {
-	bool test;
-};
-
-static struct options options = {0};
-
-static struct options
-parse_command_line(char const *string) {
-	printf("Multiboot command line: %s\n", string);
-
-	return (struct options){
-		.test = strstr(string, "test"),
-	};
-}
 
 /*
 ** This should probably go elsewhere, here only for example purposes.
@@ -43,7 +29,7 @@ multiboot_load(uintptr mb_addr)
 		switch (tag->type)
 		{
 		case MULTIBOOT_TAG_TYPE_CMDLINE:
-			options = parse_command_line(((struct multiboot_tag_string *)tag)->string);
+			options_parse_command_line(((struct multiboot_tag_string *)tag)->string);
 			break;
 		}
 		tag = (struct multiboot_tag *)((uchar *)tag + ((tag->size + 7) & ~7));
@@ -82,7 +68,7 @@ kernel_main(uintptr mb_addr)
 
 	/* Drivers hooks would go there */
 
-	if (options.test) {
+	if (get_options().test) {
 		test();
 	}
 

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -12,11 +12,31 @@
 #include <kernel/vmm.h>
 #include <multiboot2.h>
 #include <stdio.h>
+#include <string.h>
+
+typedef struct {
+	bool test;
+} options_t;
+
+static options_t options = {0};
+
+static options_t
+parse_command_line(char const *string) {
+	options_t options = {0};
+
+	printf("Multiboot command line: %s\n", string);
+
+	if (strstr(string, "test")) {
+		options.test = true;
+	}
+
+	return options;
+}
 
 /*
 ** This should probably go elsewhere, here only for example purposes.
 */
-void
+static void
 multiboot_load(uintptr mb_addr)
 {
 	struct multiboot_tag *tag;
@@ -27,11 +47,17 @@ multiboot_load(uintptr mb_addr)
 		switch (tag->type)
 		{
 		case MULTIBOOT_TAG_TYPE_CMDLINE:
-			printf("Command line: %s\n", ((struct multiboot_tag_string *)tag)->string);
+			options = parse_command_line(((struct multiboot_tag_string *)tag)->string);
 			break;
 		}
 		tag = (struct multiboot_tag *)((uchar *)tag + ((tag->size + 7) & ~7));
 	}
+}
+
+static void test() {
+	printf("Running tests...\n");
+	pmm_test();
+	printf("Done.\n");
 }
 
 /*
@@ -59,7 +85,12 @@ kernel_main(uintptr mb_addr)
 
 	/* Drivers hooks would go there */
 
+	if (options.test) {
+		test();
+	}
+
 	/* We're now ready to go on */
 	printf("\nWelcome to ChaOS\n\n");
+
 	return (0);
 }

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -14,17 +14,17 @@
 #include <stdio.h>
 #include <string.h>
 
-typedef struct {
+struct options {
 	bool test;
-} options_t;
+};
 
-static options_t options = {0};
+static struct options options = {0};
 
-static options_t
+static struct options
 parse_command_line(char const *string) {
 	printf("Multiboot command line: %s\n", string);
 
-	return (options_t){
+	return (struct options){
 		.test = strstr(string, "test"),
 	};
 }

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -22,15 +22,11 @@ static options_t options = {0};
 
 static options_t
 parse_command_line(char const *string) {
-	options_t options = {0};
-
 	printf("Multiboot command line: %s\n", string);
 
-	if (strstr(string, "test")) {
-		options.test = true;
-	}
-
-	return options;
+	return (options_t){
+		.test = strstr(string, "test"),
+	};
 }
 
 /*
@@ -57,6 +53,7 @@ multiboot_load(uintptr mb_addr)
 static void test() {
 	printf("Running tests...\n");
 	pmm_test();
+	string_test();
 	printf("Done.\n");
 }
 

--- a/kernel/options.c
+++ b/kernel/options.c
@@ -1,0 +1,35 @@
+/* ------------------------------------------------------------------------ *\
+**
+**  This file is part of the Chaos Kernel, and is made available under
+**  the terms of the GNU General Public License version 2.
+**
+**  Copyright (C) 2017 - Benjamin Grange <benjamin.grange@epitech.eu>
+**
+\* ------------------------------------------------------------------------ */
+
+#include <kernel/options.h>
+#include <string.h>
+#include <stdio.h>
+
+static struct options options = {0};
+
+static struct options
+parse_command_line(char const *string)
+{
+	printf("Multiboot command line: %s\n", string);
+
+	return ((struct options){
+		.test = strstr(string, "test"),
+	});
+}
+
+void
+options_parse_command_line(char const *string)
+{
+	options = parse_command_line(string);
+}
+
+struct options
+get_options(void) {
+	return (options);
+}

--- a/kernel/pmm.c
+++ b/kernel/pmm.c
@@ -92,7 +92,6 @@ pmm_init(void)
 {
 	next_frame = 0u;
 	memset(frame_bitmap, 0, sizeof(frame_bitmap));
-	pmm_unit_tests();
 	printf("[OK]\tPhysical Memory Managment\n");
 }
 
@@ -100,11 +99,10 @@ pmm_init(void)
 ** Some unit tests for the frame allocator.
 **
 ** TODO Write a unit-test framework within the kernel,
-** called using multiboot arguments, so that we can test all
-** of this through Travis.
+** so that we can test all of this through Travis.
 */
-__used void
-pmm_unit_tests(void)
+void
+pmm_test(void)
 {
 	assert_eq(alloc_frame(), 0x0000);
 	assert_eq(alloc_frame(), 0x1000);

--- a/lib/libc/string.c
+++ b/lib/libc/string.c
@@ -24,17 +24,61 @@ strlen(char const *str)
 static bool
 starts_with(char const *string, char const *prefix)
 {
-	return !*prefix ? true :
-		*string == *prefix ? starts_with(string + 1, prefix + 1) :
-		false;
+	while (*string && *string == *prefix) {
+		++string;
+		++prefix;
+	}
+	return (!*prefix);
+}
+
+static void
+starts_with_test(void)
+{
+	assert(starts_with("", ""));
+	assert(!starts_with("", "a"));
+	assert(starts_with("a", ""));
+	assert(starts_with("a", "a"));
+	assert(starts_with("boat", "boa"));
+	assert(starts_with("boat", "boat"));
+	assert(!starts_with(" boat", "boat"));
 }
 
 char
 *strstr(char const *haystack, char const *needle)
 {
-	return starts_with(haystack, needle) ? (char *)haystack :
-		*haystack ? strstr(haystack + 1, needle) :
-		NULL;
+	while (true) {
+		if (starts_with(haystack, needle)) {
+			return (char *)haystack;
+		}
+		if (!*haystack) {
+			return (NULL);
+		}
+		++haystack;
+	}
+}
+
+static ptrdiff_t
+strstr_index(char const *haystack, char const *needle)
+{
+	char const *result = strstr(haystack, needle);
+	if (!result) {
+		return (-1);
+	}
+	assert(result >= haystack);
+	if (strlen(haystack)) {
+		assert(result < haystack + strlen(haystack));
+	}
+	return (result - haystack);
+}
+
+static void
+strstr_test(void)
+{
+	assert(strstr_index("", "") == 0);
+	assert(strstr_index("a", "") == 0);
+	assert(strstr_index("a", "a") == 0);
+	assert(strstr_index("ba", "a") == 1);
+	assert(strstr_index("", "a") == -1);
 }
 
 void *
@@ -121,4 +165,11 @@ memchr(void const *src, int c, size_t n)
 		--n;
 	}
 	return (NULL);
+}
+
+void
+string_test(void)
+{
+	starts_with_test();
+	strstr_test();
 }

--- a/lib/libc/string.c
+++ b/lib/libc/string.c
@@ -7,7 +7,7 @@
 **
 \* ------------------------------------------------------------------------ */
 
-#include <stddef.h>
+#include <string.h>
 
 size_t
 strlen(char const *str)
@@ -19,6 +19,22 @@ strlen(char const *str)
 		++s;
 	}
 	return ((size_t)(s - str));
+}
+
+static bool
+starts_with(char const *string, char const *prefix)
+{
+	return !*prefix ? true :
+		*string == *prefix ? starts_with(string + 1, prefix + 1) :
+		false;
+}
+
+char
+*strstr(char const *haystack, char const *needle)
+{
+	return starts_with(haystack, needle) ? (char *)haystack :
+		*haystack ? strstr(haystack + 1, needle) :
+		NULL;
 }
 
 void *

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -25,4 +25,4 @@ COPY Makefile /chaos/Makefile
 RUN make clean
 RUN CC=clang make kernel
 RUN make clean
-RUN make iso
+RUN make test_iso

--- a/scripts/chaos-iso.sh
+++ b/scripts/chaos-iso.sh
@@ -16,7 +16,6 @@ PROJECT_DIR="$SCRIPT_DIR/../"
 BUILD_DIR="$PROJECT_DIR/build/"
 RULES=kernel
 boot_args=${CHAOS_BOOT_ARGS:-}
-echo $boot_args
 
 if [ ! -f "$BUILD_DIR/chaos.bin" ]; then
 	echo -e "  MAKE\t $RULES"


### PR DESCRIPTION
The way I tweaked the Makefile and `chaos-iso.sh` is possibly crappy. Moreover, my recursive implementation of `strstr()` is probably not suitable for kernel hacking.

Feel free to rewrite everything.

Fix #12.